### PR TITLE
fix: Rich library compatibility - SpinnerColumn API fix

### DIFF
--- a/src/localport/cli/utils/progress_utils.py
+++ b/src/localport/cli/utils/progress_utils.py
@@ -32,7 +32,7 @@ class EnhancedProgress:
             Configured Progress instance
         """
         columns = [
-            SpinnerColumn(spinner_style="cyan"),
+            SpinnerColumn(style="cyan"),
             TextColumn("[progress.description]{task.description}"),
         ]
         
@@ -56,7 +56,7 @@ class EnhancedProgress:
             Configured Progress instance
         """
         return Progress(
-            SpinnerColumn(spinner_style="cyan"),
+            SpinnerColumn(style="cyan"),
             TextColumn("[progress.description]{task.description}"),
             BarColumn(bar_width=30),
             MofNCompleteColumn(),


### PR DESCRIPTION
# 🐛 Critical Bug Fix - Rich Library Compatibility

## **Issue Fixed**
Resolves TypeError in progress indicators when using newer versions of the Rich library.

## **Problem**
Users reported daemon start failures with the following error:


## **Root Cause**
The Rich library changed the SpinnerColumn API in recent versions:
- **Old API**: 
- **New API**: 

## **Solution**
- Updated  method to use  parameter
- Updated  method to use  parameter
- Maintains visual styling while ensuring compatibility across Rich versions

## **Testing**
- ✅ Tested on Ubuntu with newer Rich version - daemon starts successfully
- ✅ Tested on macOS with current Rich version - no regressions
- ✅ Progress indicators display correctly with cyan styling
- ✅ All daemon operations work as expected

## **Impact**
- **Critical**: Fixes daemon start failures for users with newer Rich versions
- **Compatibility**: Ensures LocalPort works across different Rich library versions
- **No Breaking Changes**: Maintains all existing functionality and visual design

This is a critical compatibility fix that should be released as v0.3.3.